### PR TITLE
Add Next Level Basketball logo and program branding

### DIFF
--- a/apps/web/public/logos/next-level-basketball-progression.svg
+++ b/apps/web/public/logos/next-level-basketball-progression.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240" width="200" height="240">
+  <!-- Three ascending bars -->
+  <!-- Bar 1 (shortest, lightest) -->
+  <rect x="20" y="140" width="40" height="60" fill="#C0C0C0" rx="4"/>
+  
+  <!-- Bar 2 (medium) -->
+  <rect x="80" y="100" width="40" height="100" fill="#6B6B6B" rx="4"/>
+  
+  <!-- Bar 3 (tallest, darkest) -->
+  <rect x="140" y="60" width="40" height="140" fill="#0A0A0A" rx="4"/>
+  
+  <!-- Basketball at the top -->
+  <circle cx="160" cy="35" r="30" fill="#FF4D00"/>
+  
+  <!-- Basketball seam lines -->
+  <path d="M 160 5 Q 145 35 160 65" stroke="#0A0A0A" stroke-width="2" fill="none"/>
+  <path d="M 160 5 Q 175 35 160 65" stroke="#0A0A0A" stroke-width="2" fill="none"/>
+  <ellipse cx="160" cy="35" rx="30" ry="12" stroke="#0A0A0A" stroke-width="2" fill="none"/>
+</svg>

--- a/apps/web/src/app/api/start/questions/route.ts
+++ b/apps/web/src/app/api/start/questions/route.ts
@@ -41,6 +41,8 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({
       questions: mergedQuestions,
       programName: program?.name || programId,
+      programLogoUrl: program?.logoUrl || null,
+      programSubheader: program?.subheader || null,
       ownerWordmarkUrl: owner?.wordmarkUrl || null,
       ownerDisplayName: owner?.displayName || null,
     });

--- a/apps/web/src/app/start/page.tsx
+++ b/apps/web/src/app/start/page.tsx
@@ -30,6 +30,8 @@ function StartPageContent() {
 
   const [questions, setQuestions] = useState<QuestionnaireQuestion[] | null>(null);
   const [programName, setProgramName] = useState<string | undefined>(undefined);
+  const [programLogoUrl, setProgramLogoUrl] = useState<string | undefined>(undefined);
+  const [programSubheader, setProgramSubheader] = useState<string | undefined>(undefined);
   const [ownerWordmarkUrl, setOwnerWordmarkUrl] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
 
@@ -55,6 +57,8 @@ function StartPageContent() {
         const data = await response.json();
         setQuestions(data.questions);
         setProgramName(data.programName);
+        setProgramLogoUrl(data.programLogoUrl);
+        setProgramSubheader(data.programSubheader);
         setOwnerWordmarkUrl(data.ownerWordmarkUrl);
       } catch (err) {
         console.error('Error loading questions:', err);
@@ -90,6 +94,8 @@ function StartPageContent() {
     <Questionnaire
       programId={programId}
       programName={programName}
+      programLogoUrl={programLogoUrl}
+      programSubheader={programSubheader}
       ownerWordmarkUrl={ownerWordmarkUrl}
       questions={questions}
     />

--- a/apps/web/src/components/pages/owner-landing/next-level-basketball/NextLevelHero.tsx
+++ b/apps/web/src/components/pages/owner-landing/next-level-basketball/NextLevelHero.tsx
@@ -23,10 +23,20 @@ export function NextLevelHero({ startUrl = '/start' }: NextLevelHeroProps) {
       </div>
 
       <div className="relative z-10 container mx-auto px-4 text-center pt-16 lg:pt-0">
-        <div className="hidden lg:inline-block mb-4 px-4 py-1 border border-white/20 rounded-full bg-white/10 backdrop-blur-md">
-          <span className="text-white/90 text-sm font-semibold tracking-wider uppercase">
-            GymText Presents
-          </span>
+        {/* Next Level Basketball Logo */}
+        <div className="flex flex-col items-center mb-6 md:mb-8">
+          <Image
+            src="/logos/next-level-basketball-progression.svg"
+            alt="Next Level Basketball"
+            width={120}
+            height={144}
+            className="mb-4 w-20 md:w-28 h-auto"
+          />
+          <div className="hidden lg:inline-block px-4 py-1 border border-white/20 rounded-full bg-white/10 backdrop-blur-md">
+            <span className="text-white/90 text-sm font-semibold tracking-wider uppercase">
+              GymText Presents
+            </span>
+          </div>
         </div>
 
         <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-8xl font-display font-bold text-white mb-4 md:mb-6 tracking-tight leading-tight">

--- a/apps/web/src/components/questionnaire/Questionnaire.tsx
+++ b/apps/web/src/components/questionnaire/Questionnaire.tsx
@@ -33,11 +33,13 @@ import { TimeSelectorQuestion } from './questions/TimeSelectorQuestion';
 interface QuestionnaireProps {
   programId?: string;
   programName?: string;
+  programLogoUrl?: string;
+  programSubheader?: string;
   ownerWordmarkUrl?: string;
   questions: QuestionnaireQuestion[];
 }
 
-export function Questionnaire({ programId, programName, ownerWordmarkUrl, questions }: QuestionnaireProps) {
+export function Questionnaire({ programId, programName, programLogoUrl, programSubheader, ownerWordmarkUrl, questions }: QuestionnaireProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Track consent separately from questionnaire answers
@@ -369,14 +371,39 @@ export function Questionnaire({ programId, programName, ownerWordmarkUrl, questi
 
       {/* Branding header */}
       <div className="flex flex-col items-center gap-1 py-4">
-        {ownerWordmarkUrl ? (
-          <img src={ownerWordmarkUrl} alt="" className="h-8 object-contain" />
+        {programLogoUrl ? (
+          <>
+            <img src={programLogoUrl} alt={programName || ''} className="h-16 object-contain mb-1" />
+            {programName && (
+              <h2 className="text-lg font-bold text-[hsl(var(--questionnaire-foreground))]">
+                {programName}
+              </h2>
+            )}
+            {programSubheader && (
+              <p className="text-sm text-[hsl(var(--questionnaire-muted-foreground))]">
+                {programSubheader}
+              </p>
+            )}
+            <div className="flex items-center gap-1.5 mt-2 text-xs text-[hsl(var(--questionnaire-muted-foreground))]">
+              <span>Powered by</span>
+              <img src="/Wordmark.png" alt="GymText" className="h-4 object-contain" />
+            </div>
+          </>
+        ) : ownerWordmarkUrl ? (
+          <>
+            <img src={ownerWordmarkUrl} alt="" className="h-8 object-contain" />
+            <span className="text-sm text-[hsl(var(--questionnaire-muted-foreground))]">
+              {programName || 'Sign Up'}
+            </span>
+          </>
         ) : (
-          <img src="/Wordmark.png" alt="GymText" className="h-8 object-contain" />
+          <>
+            <img src="/Wordmark.png" alt="GymText" className="h-8 object-contain" />
+            <span className="text-sm text-[hsl(var(--questionnaire-muted-foreground))]">
+              {programName || 'Sign Up'}
+            </span>
+          </>
         )}
-        <span className="text-sm text-[hsl(var(--questionnaire-muted-foreground))]">
-          {programName || 'Sign Up'}
-        </span>
       </div>
 
       {/* Header with progress */}

--- a/migrations/20260331000000_add_program_branding.ts
+++ b/migrations/20260331000000_add_program_branding.ts
@@ -1,0 +1,22 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Add logoUrl and subheader to programs table for program-specific branding
+  await sql`
+    ALTER TABLE programs ADD COLUMN logo_url TEXT
+  `.execute(db);
+
+  await sql`
+    ALTER TABLE programs ADD COLUMN subheader TEXT
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE programs DROP COLUMN subheader
+  `.execute(db);
+
+  await sql`
+    ALTER TABLE programs DROP COLUMN logo_url
+  `.execute(db);
+}

--- a/packages/shared/src/server/models/program.ts
+++ b/packages/shared/src/server/models/program.ts
@@ -26,6 +26,10 @@ export interface Program {
   publishedVersionId: string | null;
   /** ID of the cover image for this program */
   coverImageId: string | null;
+  /** URL of the program logo (for signup page branding) */
+  logoUrl: string | null;
+  /** Subheader text for program branding */
+  subheader: string | null;
   isActive: boolean;
   isPublic: boolean;
   createdAt: Date;
@@ -47,6 +51,8 @@ export class ProgramModel {
       revenueSplitPercent: row.revenueSplitPercent,
       publishedVersionId: row.publishedVersionId,
       coverImageId: row.coverImageId ?? null,
+      logoUrl: (row as any).logoUrl ?? null,
+      subheader: (row as any).subheader ?? null,
       isActive: row.isActive,
       isPublic: row.isPublic,
       createdAt: new Date(row.createdAt as unknown as string | number | Date),


### PR DESCRIPTION
## Changes

Based on the brand identity system PowerPoint, this PR adds:

### 1. Next Level Basketball Logo on Landing Page
- Created SVG logo based on 'The Progression' concept
- Three ascending bars (light gray → medium gray → onyx) with basketball on top
- Brand colors: Onyx (#0A0A0A), Blaze (#FF4D00)
- Integrated into hero section above headline
- Responsive sizing (mobile: 80px, desktop: 112px)

### 2. Program Logo & Subheader Support on Signup Page
- Added `logo_url` and `subheader` columns to `programs` table
- Updated Program model to include new fields
- Updated `/api/start/questions` to return program branding
- Updated Questionnaire component with new branding hierarchy:
  - If program has logo: Show program logo (64px), name as heading, subheader, + "Powered by GymText" badge
  - Else if owner has wordmark: Show owner wordmark + program name
  - Else: Show GymText logo + "Sign Up"

### Migration
- `20260331000000_add_program_branding.ts` - adds logo_url and subheader to programs

### To apply Next Level Basketball branding:

After running the migration:

```sql
UPDATE programs 
SET 
  logo_url = '/logos/next-level-basketball-progression.svg',
  subheader = 'Elite basketball skills development'
WHERE sport_id = (SELECT id FROM sports WHERE slug = 'basketball')
  AND owner_id = (SELECT id FROM program_owners WHERE slug = 'nextlevelbasketball');
```

## Testing
1. Pull the branch
2. Run migrations: `source .env.local && pnpm migrate`
3. Run the SQL above to set Next Level Basketball branding
4. Visit `/o/nextlevelbasketball` - logo should appear in hero
5. Visit `/start?program={next-level-program-id}` - signup should show program logo + branding

Ready for review!