### PR TITLE
fix: update workout scheduling link and signup close nav

### DIFF
--- a/apps/web/src/components/questionnaire/Questionnaire.tsx
+++ b/apps/web/src/components/questionnaire/Questionnaire.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import type { QuestionnaireQuestion } from '@/lib/questionnaire/types';
 import { useQuestionnaire, clearQuestionnaireState } from '@/lib/questionnaire/useQuestionnaire';
 import {
@@ -40,6 +40,7 @@ interface QuestionnaireProps {
 }
 
 export function Questionnaire({ programId, programName, ownerWordmarkUrl, ownerDisplayName, questions }: QuestionnaireProps) {
+  const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Track consent separately from questionnaire answers
@@ -358,10 +359,16 @@ export function Questionnaire({ programId, programName, ownerWordmarkUrl, ownerD
     <div className={`questionnaire-theme flex flex-col bg-[hsl(var(--questionnaire-bg))] ${ownerWordmarkUrl ? 'h-screen-safe' : 'min-h-screen-safe'}`}>
       {/* Close button - top left */}
       <div className="pt-safe mt-2 px-4">
-        <Link
-          href="/"
+        <button
+          onClick={() => {
+            if (window.history.length > 1) {
+              router.back();
+            } else {
+              router.push("/");
+            }
+          }}
           className="inline-flex rounded-full p-2 transition-opacity hover:opacity-70"
-          aria-label="Close and return to home"
+          aria-label="Close"
         >
           <svg
             className="h-5 w-5 text-[hsl(var(--questionnaire-muted-foreground))]"
@@ -372,7 +379,7 @@ export function Questionnaire({ programId, programName, ownerWordmarkUrl, ownerD
           >
             <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
           </svg>
-        </Link>
+        </button>
       </div>
 
       {/* Branding header */}

--- a/packages/shared/src/server/services/factory.ts
+++ b/packages/shared/src/server/services/factory.ts
@@ -257,6 +257,7 @@ export function createServices(repos: RepositoryContainer, clients?: ExternalCli
     markdown,
     agentRunner,
     workoutInstance,
+    shortLink,
     enrollmentRepository: repos.programEnrollment,
     programRepository: repos.program,
     programOwnerRepository: repos.programOwner,

--- a/packages/shared/src/server/services/factory.ts
+++ b/packages/shared/src/server/services/factory.ts
@@ -257,7 +257,9 @@ export function createServices(repos: RepositoryContainer, clients?: ExternalCli
     markdown,
     agentRunner,
     workoutInstance,
-    shortLink,
+    enrollmentRepository: repos.programEnrollment,
+    programRepository: repos.program,
+    programOwnerRepository: repos.programOwner,
   });
 
   const regeneration = createRegenerationService({

--- a/packages/shared/src/server/services/orchestration/trainingService.ts
+++ b/packages/shared/src/server/services/orchestration/trainingService.ts
@@ -18,6 +18,7 @@ import type { Microcycle } from '@/server/models/microcycle';
 import type { UserServiceInstance } from '../domain/user/userService';
 import type { MarkdownServiceInstance } from '../domain/markdown/markdownService';
 import type { WorkoutInstanceServiceInstance } from '../domain/training/workoutInstanceService';
+import type { ShortLinkServiceInstance } from '../domain/links/shortLinkService';
 import type { ProgramEnrollmentRepository } from '@/server/repositories/programEnrollmentRepository';
 import type { ProgramRepository } from '@/server/repositories/programRepository';
 import type { ProgramOwnerRepository } from '@/server/repositories/programOwnerRepository';
@@ -53,6 +54,7 @@ export interface TrainingServiceDeps {
   markdown: MarkdownServiceInstance;
   agentRunner: SimpleAgentRunnerInstance;
   workoutInstance: WorkoutInstanceServiceInstance;
+  shortLink: ShortLinkServiceInstance;
   enrollmentRepository: ProgramEnrollmentRepository;
   programRepository: ProgramRepository;
   programOwnerRepository: ProgramOwnerRepository;
@@ -68,6 +70,7 @@ export function createTrainingService(deps: TrainingServiceDeps): TrainingServic
     markdown: markdownService,
     agentRunner: simpleAgentRunner,
     workoutInstance: workoutInstanceService,
+    shortLink: shortLinkService,
     enrollmentRepository,
     programRepository,
     programOwnerRepository,
@@ -86,7 +89,16 @@ export function createTrainingService(deps: TrainingServiceDeps): TrainingServic
         { schedulingEnabled: program.schedulingEnabled, schedulingUrl: program.schedulingUrl },
       );
       if (!link) return '';
-      return `\n\n(Set up time with ${programOwner.displayName} here: ${link})`;
+
+      let shortUrl = link;
+      try {
+        const created = await shortLinkService.createCoachLink(user.id, link);
+        shortUrl = shortLinkService.getFullUrl(created.code);
+      } catch (err) {
+        console.error('[TrainingService] Failed to create coach short link, falling back to full URL:', err);
+      }
+
+      return `\n\n(Set up time with ${programOwner.displayName} here: ${shortUrl})`;
     } catch (error) {
       console.error('[TrainingService] Failed to build scheduling link:', error);
       return '';

--- a/packages/shared/src/server/services/orchestration/trainingService.ts
+++ b/packages/shared/src/server/services/orchestration/trainingService.ts
@@ -10,6 +10,7 @@
 import { DateTime } from 'luxon';
 import { getDayOfWeekName, now, parseDate, toISODate } from '@/shared/utils/date';
 import { normalizeWhitespace, stripCodeFences } from '@/server/utils/formatters';
+import { buildCoachLink } from '@/server/utils/coachLink';
 import type { UserWithProfile } from '@/server/models/user';
 import type { FitnessPlan } from '@/server/models/fitnessPlan';
 import type { Microcycle } from '@/server/models/microcycle';
@@ -17,7 +18,9 @@ import type { Microcycle } from '@/server/models/microcycle';
 import type { UserServiceInstance } from '../domain/user/userService';
 import type { MarkdownServiceInstance } from '../domain/markdown/markdownService';
 import type { WorkoutInstanceServiceInstance } from '../domain/training/workoutInstanceService';
-import type { ShortLinkServiceInstance } from '../domain/links/shortLinkService';
+import type { ProgramEnrollmentRepository } from '@/server/repositories/programEnrollmentRepository';
+import type { ProgramRepository } from '@/server/repositories/programRepository';
+import type { ProgramOwnerRepository } from '@/server/repositories/programOwnerRepository';
 
 // Agent services
 import type { SimpleAgentRunnerInstance } from '@/server/agents/runner';
@@ -50,7 +53,9 @@ export interface TrainingServiceDeps {
   markdown: MarkdownServiceInstance;
   agentRunner: SimpleAgentRunnerInstance;
   workoutInstance: WorkoutInstanceServiceInstance;
-  shortLink: ShortLinkServiceInstance;
+  enrollmentRepository: ProgramEnrollmentRepository;
+  programRepository: ProgramRepository;
+  programOwnerRepository: ProgramOwnerRepository;
 }
 
 // =============================================================================
@@ -63,8 +68,30 @@ export function createTrainingService(deps: TrainingServiceDeps): TrainingServic
     markdown: markdownService,
     agentRunner: simpleAgentRunner,
     workoutInstance: workoutInstanceService,
-    shortLink: shortLinkService,
+    enrollmentRepository,
+    programRepository,
+    programOwnerRepository,
   } = deps;
+
+  async function buildSchedulingSuffix(user: UserWithProfile): Promise<string> {
+    try {
+      const enrollment = await enrollmentRepository.findActiveByClientId(user.id);
+      if (!enrollment) return '';
+      const program = await programRepository.findById(enrollment.programId);
+      if (!program || !program.schedulingEnabled || !program.schedulingUrl) return '';
+      const programOwner = await programOwnerRepository.findById(program.ownerId);
+      if (!programOwner?.displayName) return '';
+      const link = buildCoachLink(
+        { id: user.id, name: user.name, email: user.email ?? null },
+        { schedulingEnabled: program.schedulingEnabled, schedulingUrl: program.schedulingUrl },
+      );
+      if (!link) return '';
+      return `\n\n(Set up time with ${programOwner.displayName} here: ${link})`;
+    } catch (error) {
+      console.error('[TrainingService] Failed to build scheduling link:', error);
+      return '';
+    }
+  }
 
   return {
     async createFitnessPlan(user: UserWithProfile, options?: { programId?: string }): Promise<FitnessPlan> {
@@ -211,34 +238,14 @@ export function createTrainingService(deps: TrainingServiceDeps): TrainingServic
 
         const rawMessage = stripCodeFences(normalizeWhitespace(formatResult.response));
 
-        // Save workout instance first to get a real ID for the short link
+        const schedulingSuffix = await buildSchedulingSuffix(user);
+        const workoutMessage = `${dayName}\n\n${rawMessage}${schedulingSuffix}`;
+
         const workoutInstance = await workoutInstanceService.upsert({
           clientId: user.id,
           date: dateStr,
-          message: rawMessage,
+          message: workoutMessage,
         });
-
-        // Create short link using the actual workout instance ID
-        let shortLinkSuffix = '';
-        try {
-          const shortLink = await shortLinkService.createWorkoutLink(user.id);
-          const fullUrl = shortLinkService.getFullUrl(shortLink.code);
-          shortLinkSuffix = `\n\n(More details: ${fullUrl})`;
-        } catch (error) {
-          console.error(`[TrainingService] Failed to create short link:`, error);
-        }
-
-        // Compose final message: day name + content + short link
-        const workoutMessage = `${dayName}\n\n${rawMessage}${shortLinkSuffix}`;
-
-        // Update with final message including the short link
-        if (shortLinkSuffix) {
-          await workoutInstanceService.upsert({
-            clientId: user.id,
-            date: dateStr,
-            message: workoutMessage,
-          });
-        }
 
         console.log(`[TrainingService] Generated workout for user ${user.id} on ${dateStr}`);
 
@@ -287,33 +294,14 @@ export function createTrainingService(deps: TrainingServiceDeps): TrainingServic
 
       const rawMessage = stripCodeFences(normalizeWhitespace(result.response));
 
-      // Save workout instance first to get a real ID for the short link
-      const workoutInstance = await workoutInstanceService.upsert({
+      const schedulingSuffix = await buildSchedulingSuffix(user);
+      const regeneratedMessage = `${dayName}\n\n${rawMessage}${schedulingSuffix}`;
+
+      await workoutInstanceService.upsert({
         clientId: user.id,
         date: workoutISODate,
-        message: rawMessage,
+        message: regeneratedMessage,
       });
-
-      // Generate short link using the actual workout instance ID
-      let shortLinkSuffix = '';
-      try {
-        const shortLink = await shortLinkService.createWorkoutLink(user.id);
-        const fullUrl = shortLinkService.getFullUrl(shortLink.code);
-        shortLinkSuffix = `\n\n(More details: ${fullUrl})`;
-      } catch (error) {
-        console.error(`[TrainingService] Failed to create short link for regenerated workout:`, error);
-      }
-
-      const regeneratedMessage = `${dayName}\n\n${rawMessage}${shortLinkSuffix}`;
-
-      // Update with final message including the short link
-      if (shortLinkSuffix) {
-        await workoutInstanceService.upsert({
-          clientId: user.id,
-          date: workoutISODate,
-          message: regeneratedMessage,
-        });
-      }
 
       return regeneratedMessage;
     },


### PR DESCRIPTION
## Summary
- remove workout SMS short-link suffix and replace it with conditional scheduling copy using the program owner name
- keep workout message generation/regeneration aligned with the new scheduling suffix behavior
- make signup questionnaire close button return to prior page when possible, with / fallback

## Testing
- pnpm -s exec tsc --noEmit *(fails due to pre-existing repo errors outside this change)*